### PR TITLE
Added ability to enable/disable existing rules

### DIFF
--- a/manifests/exception.pp
+++ b/manifests/exception.pp
@@ -187,5 +187,14 @@ define windows_firewall::exception(
       onlyif   => $onlyif,
       unless   => $unless,
     }
+    
+    if $enabled != '' {
+        exec { "turn rule on or off ${display_name}":
+            command => "C:\\Windows\\System32\\netsh.exe advfirewall firewall set rule name=\"${display_name}\" new enable=${enabled}",
+            provider => windows,
+            onlyif  => $onlyif,
+       }
+    }
+    
 }
 


### PR DESCRIPTION
Checks if $enabled is set and runs the netsh command to enable/disable the rule if the rule exists.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
